### PR TITLE
Fixed IP address octet in filename misinterpreted as extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.a
+*.o
+media/*
+version.h
+xupnpd
+xupnpd.db
+xupnpd.uid
+
+

--- a/scan.cpp
+++ b/scan.cpp
@@ -189,6 +189,7 @@ int utils::scan_playlist(const std::string& path,int parentid,int& objid,std::st
     std::map<std::string,std::string> pls_ext;
 
     std::string::size_type n=path.find_last_of("\\/");
+    std::string::size_type n2=std::string::npos;
 
     if(n!=std::string::npos)
         playlist_name=path.substr(n+1);
@@ -332,8 +333,9 @@ int utils::scan_playlist(const std::string& path,int parentid,int& objid,std::st
                             filename=track_url.substr(n,n1-n);
 
                         n=filename.find_last_of('.');
+                        n2=filename.find_last_of(':');
 
-                        if(n!=std::string::npos)
+                        if(n!=std::string::npos && (n2==std::string::npos || n2<n))
                             track_type=filename.substr(n+1);
                     }
                 }


### PR DESCRIPTION
When playlist contains udproxy url like 
`http://176.50.104.6:1234/udp/225.54.23.95:5000`
it doesn't appear in playlist's items as it is interpreted as a file with .95:5000 extension which cannot be handled by mime type parser.
I've added second check to find last ':' in filename and if it appears after last '.' it prevents last url part parsing as filename (so it defaults to mp4 mime type)